### PR TITLE
Specify encoding in file operations

### DIFF
--- a/amanda/__main__.py
+++ b/amanda/__main__.py
@@ -26,10 +26,8 @@ def main(*args):
     else:
         args = parser.parse_args()
     try:
-        with open(abspath(args.file)) as src_file:
-            #Replace different EOL sequences with "\n"
-            src = src_file.read().replace("\r\n", "\n").replace("\r", "\n")
-            src = StringIO(src)
+        with open(abspath(args.file), encoding="utf-8") as src_file:
+            src = StringIO(src_file.read())
     except FileNotFoundError:
         print(f"The file '{abspath(args.file)}' was not found on this system")
         sys.exit()

--- a/tests/test.py
+++ b/tests/test.py
@@ -114,7 +114,7 @@ def run_case(filename):
 
 def run_suite(test_cases):
     for test_case,result_file in test_cases:
-        results = open(result_file,"r")
+        results = open(result_file,"r", encoding="utf-8")
         try:
             output = run_case(test_case).strip()
             expected = results.readline().strip()


### PR DESCRIPTION
For some reason the preferred encoding on windows is not utf-8, so
every call to the 'open' function must explicitly specify the encoding.